### PR TITLE
Adding listener

### DIFF
--- a/RwecsConnect/source/bluetooth/CommunicationQueue.mc
+++ b/RwecsConnect/source/bluetooth/CommunicationQueue.mc
@@ -6,7 +6,7 @@ class CommunicationQueue {
     private static var instance = null;
 
     private var queue;
-    private var isRunning;
+    private var running;
 
     static enum {
 		CHARACTERISTIC_WRITE,
@@ -15,6 +15,7 @@ class CommunicationQueue {
 
     function initialize() {
         queue =[];
+        running = false;
     }
 
     static function getInstance() {
@@ -23,6 +24,11 @@ class CommunicationQueue {
         }
         return instance;
     }
+
+    function isRunning() {
+        return running;
+    }
+
 
     /**
     * Adds item to the request queue
@@ -36,8 +42,10 @@ class CommunicationQueue {
 
     function run() {
         if (queue.size() == 0) {
-            return;
+            return true;
         }
+
+        self.running = true; 
 
         var target = queue[0][0];
         var type = queue[0][1];
@@ -52,6 +60,12 @@ class CommunicationQueue {
 
         if( queue.size() > 0 ) {
             queue = queue.slice(1,queue.size());
-        } 
+        }
+
+        return false;
+    }
+
+    function finishRun() {
+        self.running = false;
     }
 }

--- a/RwecsConnect/source/bluetooth/DeviceController.mc
+++ b/RwecsConnect/source/bluetooth/DeviceController.mc
@@ -4,6 +4,7 @@ using Toybox.BluetoothLowEnergy as Ble;
 class DeviceController {
     private var btCtx;
     private var btReqQueue;
+    private var _timer;
 
     function initialize() {
         btCtx = BluetoothContext.getInstance();
@@ -13,22 +14,28 @@ class DeviceController {
     function enableTrainingMode() {
         _enableNotifications();
         _sendWriteCommands(btCtx.TRAINING_MODE);
-        btReqQueue.run();
     }
 
     function resetDevice() {
+        _timer = new Timer.Timer();
         _sendWriteCommands(btCtx.INITIAL_STATE);
         btReqQueue.run();
+        _timer.start(method(:runRequests), 1000, true);
+              
     }
 
     private function _sendWriteCommands(command) {
         var devices = Ble.getPairedDevices() as Ble.Iterator;
         var currentDevice = devices.next();
         while (currentDevice != null ) {
-            try {
-                var service = currentDevice.getService(btCtx.customService());
-                var controller = service.getCharacteristic(btCtx.customServiceControl());
-                btReqQueue.add(controller, btReqQueue.CHARACTERISTIC_WRITE, command );
+            try { 
+                if (currentDevice.isConnected()) {
+                    var service = currentDevice.getService(btCtx.customService());
+                    var controller = service.getCharacteristic(btCtx.customServiceControl());
+                    btReqQueue.add(controller, btReqQueue.CHARACTERISTIC_WRITE, command );
+                } else {
+                    System.println("Warning a device is not paired fully");
+                }
             } catch (e) {
                 System.println(e.getErrorMessage());
             }
@@ -41,13 +48,27 @@ class DeviceController {
         var currentDevice = devices.next() as Ble.Device;
         while (currentDevice != null ) {
             try {
-                var service = currentDevice.getService(btCtx.customService());
-                var read = service.getCharacteristic(btCtx.customServiceRead());
-                btReqQueue.add(read, btReqQueue.DESCRIPTOR_WRITE, btCtx.ENABLE_NOTIFY);
+                if (currentDevice.isConnected()) {
+                    var service = currentDevice.getService(btCtx.customService());
+                    var read = service.getCharacteristic(btCtx.customServiceRead());
+                    btReqQueue.add(read, btReqQueue.DESCRIPTOR_WRITE, btCtx.ENABLE_NOTIFY);
+                } else {
+                    System.println("Warning a device is not paired fully");
+                }
             } catch (e) {
                 System.println(e.getErrorMessage());
             }
             currentDevice = devices.next();
+        }
+    }
+
+    function runRequests() {
+        var isFinished;
+        if (!btReqQueue.isRunning()) {
+            isFinished = btReqQueue.run();
+            if (isFinished) {
+                _timer.stop();
+            }
         }
     }
 }

--- a/RwecsConnect/source/ui-client/DeviceConnectionMenu.mc
+++ b/RwecsConnect/source/ui-client/DeviceConnectionMenu.mc
@@ -4,13 +4,6 @@ class DeviceConnectionMenu extends WatchUi.Menu2 {
     
     function initialize(deviceNames) {
         Menu2.initialize({:title=>"Available devices:"});
-        //TODO figure out how to add icon 
-        // var icon = new WatchUi.Bitmap({
-        //     :rezId=>Rez.Drawables.BLEIcon,
-        //     :locX=>5,
-        //     :locY=>5
-        // });
-        // setIcon(icon);
         addItems(deviceNames);
     }
     private function addItems(deviceNames) {

--- a/RwecsConnect/source/ui-delegate/DeviceConnectionProgressDelegate.mc
+++ b/RwecsConnect/source/ui-delegate/DeviceConnectionProgressDelegate.mc
@@ -37,7 +37,7 @@ class DeviceConnectionProgressDelegate extends WatchUi.BehaviorDelegate {
         }
         else if (_timerCount > 10) {
             _timer.stop();
-            _btHandler.unpairDevices();
+            _btHandler.undoPairing(_deviceName);
             WatchUi.popView(WatchUi.SLIDE_RIGHT);
         }
     }

--- a/RwecsConnect/source/ui-delegate/SettingsDelegate.mc
+++ b/RwecsConnect/source/ui-delegate/SettingsDelegate.mc
@@ -26,12 +26,6 @@ class SettingsDelegate extends WatchUi.InputDelegate {
             _view.updateAlarmLimitElement();
         }
 
-        //Start button is pressed
-        // else if (keyEvent.getKey() == WatchUi.KEY_ENTER) {
-        //     var newWorkoutView = new WorkoutView();
-        //     WatchUi.switchToView(newWorkoutView, new WorkoutDelegate(newWorkoutView), WatchUi.SLIDE_UP); 
-        // }
-
         //Back button is pressed
         else if (keyEvent.getKey() == WatchUi.KEY_ESC) {
             WatchUi.switchToView(new MainMenu(), new MainMenuDelegate(), WatchUi.SLIDE_DOWN);

--- a/RwecsConnect/source/ui-delegate/WorkoutPrepDelegate.mc
+++ b/RwecsConnect/source/ui-delegate/WorkoutPrepDelegate.mc
@@ -6,6 +6,7 @@ class WorkoutPrepDelegate extends WatchUi.BehaviorDelegate {
     private var _timer;
     private var _timerCount;
     private var _deviceController;
+    private var _btRequestQueue;
 
     function initialize() {
         BehaviorDelegate.initialize();
@@ -14,7 +15,8 @@ class WorkoutPrepDelegate extends WatchUi.BehaviorDelegate {
         _timer = new Timer.Timer();
         _deviceController = new DeviceController();
         _deviceController.enableTrainingMode();
-        _timer.start(method(:timerCallBack), 1000, true);
+        _btRequestQueue = CommunicationQueue.getInstance();
+        _timer.start(method(:timerCallBack), 500, true);
         
     }
 
@@ -23,14 +25,22 @@ class WorkoutPrepDelegate extends WatchUi.BehaviorDelegate {
     }
     
     function timerCallBack() {
+        var isFinished;
+        if (!_btRequestQueue.isRunning()) {
+            isFinished = _btRequestQueue.run();
+            if (isFinished) {
+                _timer.stop();
+                var view = new WorkoutView();
+                WatchUi.popView(WatchUi.SLIDE_UP);
+                WatchUi.pushView(view, new WorkoutDelegate(view, _deviceController), WatchUi.SLIDE_UP);
+            }
+        }
+        
         _timerCount++;
 
-        if (_timerCount == 2) {
+        if (_timerCount == 15) {
             _timer.stop();
-
-            var view = new WorkoutView();
             WatchUi.popView(WatchUi.SLIDE_UP);
-            WatchUi.pushView(view, new WorkoutDelegate(view, _deviceController), WatchUi.SLIDE_UP);
         }
     }
 }


### PR DESCRIPTION
### Description
This changes how the Bluetooth command queue works, and makes it so you cannot start a workout before the device is completely initialized

This also addresses the concern that when one device fails to pair both devices become unpaired

### TODO
<!-- PLEASE feel free to change these to track what needs to be done -->
- [x] Code follows project coding guidelines.
- [x] Documentation reflects the changes made.
- [x] Provide Proof it's working

### Changes Made
Added a running flag to the bt command queue

### Related Issues
https://github.com/Garmin-Race-Walking-App-Developers/Garmin-Race-Walking-App/issues/4

### How was this tested?

https://github.com/Garmin-Race-Walking-App-Developers/Garmin-Race-Walking-App/assets/94511816/86ef70a7-261d-435b-8705-368734a5c01b

